### PR TITLE
adding libra-web-wallet-utils package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "generate:package": "plop package && yarn plop docs",
     "tophat": "tophat",
     "graphiql": "yarn --cwd packages/libra-rpc-graphql run start",
-    "graphql": "yarn run graphiql"
+    "graphql": "yarn run graphiql",
+    "wallet": "yarn --cwd packages/libra-web-wallet-utils wallet"
   },
   "repository": {
     "type": "git",

--- a/packages/libra-web-wallet-utils/CHANGELOG.md
+++ b/packages/libra-web-wallet-utils/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/libra-web-wallet-utils` package

--- a/packages/libra-web-wallet-utils/README.md
+++ b/packages/libra-web-wallet-utils/README.md
@@ -1,0 +1,14 @@
+# `@shopify/libra-web-wallet-utils`
+
+[![Build Status](https://travis-ci.org/Shopify/web-tools.svg?branch=master)](https://travis-ci.org/Shopify/web-tools)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Flibra-web-wallet-utils.svg)](https://badge.fury.io/js/%40shopify%2Flibra-web-wallet-utils.svg)  [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/libra-web-wallet-utils.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/libra-web-wallet-utils.svg) 
+
+A collection of web utilities to work with libra wallets.
+
+## Installation
+
+```bash
+$ yarn add @shopify/libra-web-wallet-utils
+```
+
+## Usage

--- a/packages/libra-web-wallet-utils/package.json
+++ b/packages/libra-web-wallet-utils/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@shopify/libra-web-wallet-utils",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "A collection of web utilities to work with libra wallets.",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc --p tsconfig.json",
+    "wallet": "ts-node --transpile-only scripts/wallet.ts"
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/libra-web-tools.git",
+    "directory": "packages/libra-web-wallet-utils"
+  },
+  "bugs": {
+    "url": "https://github.com/Shopify/libra-web-tools/issues"
+  },
+  "homepage": "https://github.com/Shopify/libra-web-tools/blob/master/packages/libra-web-wallet-utils/README.md",
+  "dependencies": {
+    "bip39": "^3.0.0",
+    "elliptic": "^6.0.0",
+    "futoin-hkdf": "^1.0.0",
+    "pbkdf2": "^3.0.0",
+    "sha3": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/elliptic": "^6.0.0",
+    "@types/pbkdf2": "^3.0.0",
+    "protobufjs": "^6.0.0",
+    "ts-node": "^8.0.0"
+  },
+  "files": ["dist/*", "!tsconfig.tsbuildinfo"]
+}

--- a/packages/libra-web-wallet-utils/scripts/wallet.ts
+++ b/packages/libra-web-wallet-utils/scripts/wallet.ts
@@ -1,0 +1,166 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
+import {
+  generateKeyPair,
+  generateSeedKey,
+  generateSeedPhrase,
+  keyPairFromSecret,
+} from '../src/generators';
+import {
+  generateTransferTransaction,
+  LibraProgramArgumentType,
+  signTransferTrasaction,
+} from '../src/transaction';
+import {sha3hash} from '../src/utilities/sha3hash';
+
+const runner = process.argv.slice(0, 2).join(' ');
+const [command = 'help', ...args] = process.argv.slice(2);
+
+function help() {
+  const actions = [
+    'seed[:{phrase|words|key|all}]',
+    'account[:{seed|secret|public|address|all}] [seed|...phrase] [index]',
+    'transfer[:payload|debug] {fromSecretKey} {toAddress} {amount} {sequenceNumber}',
+  ];
+  console.log(
+    `
+Usage: ${runner} {action}[:format] [...args]
+
+Actions:\n${actions.map((line) => `  ${line}`).join('\n')}`.trim(),
+  );
+  process.exit(0);
+}
+
+export function seed() {
+  const phrase = generateSeedPhrase();
+  const key = generateSeedKey(phrase).toString('hex');
+  const all = [`Phrase: ${phrase}`, `   Key: ${key}`].join('\n');
+
+  return {
+    phrase,
+    words: phrase.split(' ').join(','),
+    key,
+    all,
+    default: all,
+  };
+}
+
+export function account(args: string[] = []) {
+  function parseSeed() {
+    if (args.length <= 2) {
+      const [seed = generateSeedKey().toString('hex'), index = '0'] = args;
+
+      return {seed, index};
+    }
+
+    const index = Number(args[args.length - 1]);
+    const hasIndex = !isNaN(index);
+    const phrase = args.slice(0, hasIndex ? -1 : args.length).join(' ');
+    const seed = generateSeedKey(phrase).toString('hex');
+
+    return {
+      phrase,
+      seed,
+      index: hasIndex ? String(index) : '0',
+    };
+  }
+
+  const {index, phrase, seed} = parseSeed();
+  const keyPair = generateKeyPair(seed, Number(index));
+  const address = sha3hash(keyPair.getPublic()).toString('hex');
+
+  const details = {
+    phrase,
+    seed,
+    index,
+    secret: keyPair.getSecret('hex'),
+    public: keyPair.getPublic('hex'),
+    address,
+    short: address.slice(-32),
+    prefix: address.slice(0, 32),
+  };
+  const all = [
+    ` Phrase: ${phrase || 'N/A'}`,
+    `   Seed: ${seed}`,
+    `  Index: ${index}`,
+    ` Secret: ${details.secret}`,
+    ` Public: ${details.public}`,
+    `Address: ${details.address}`,
+    `  Short: ${details.short}`,
+    ` Prefix: ${details.prefix}`,
+  ].join('\n');
+
+  return {
+    ...details,
+    all,
+    default: all,
+  };
+}
+
+export function transfer([from, to, amount, sequence]: string[]) {
+  const keyPair = keyPairFromSecret(from);
+  const tx = generateTransferTransaction(
+    Number(amount),
+    to,
+    sha3hash(keyPair.getPublic()),
+    Number(sequence),
+  );
+  const payload = [
+    '',
+    '***************',
+    '*** WARNING *** transaction signing is not functioning correctly',
+    '***************',
+    '',
+    signTransferTrasaction(keyPair, tx).toString('hex'),
+  ].join('\n');
+
+  const debug = JSON.stringify(
+    {
+      ...tx,
+      senderAccount: tx.senderAccount.toString('hex'),
+      payload: {
+        arguments: tx.payload.arguments.map(({type, value}) => ({
+          type: LibraProgramArgumentType[type],
+          value: value.toString('hex'),
+        })),
+        code: tx.payload.code.toString('hex'),
+      },
+      expirationTime: new Date(tx.expirationTime * 1000),
+    },
+    null,
+    2,
+  );
+
+  const all = [`payload: ${payload}`, `debug: ${debug}`].join('\n');
+
+  return {
+    debug,
+    payload,
+    all,
+    default: all,
+  };
+}
+
+const [, action = 'help', format = undefined] = /^(\w+)(?::(\w+))?$/.exec(
+  command,
+);
+
+switch (action) {
+  case 'seed': {
+    console.log(seed()[format || 'default']);
+    break;
+  }
+  case 'account': {
+    console.log(account(args)[format || 'default']);
+    break;
+  }
+  case 'transfer': {
+    console.log(transfer(args)[format || 'default']);
+    break;
+  }
+  default: {
+    help();
+    break;
+  }
+}

--- a/packages/libra-web-wallet-utils/src/LibraAccount.ts
+++ b/packages/libra-web-wallet-utils/src/LibraAccount.ts
@@ -1,0 +1,69 @@
+import {eddsa} from 'elliptic';
+
+import {generateKeyPair, keyPairFromSecret} from './generators';
+// import {signTransactionData} from './transaction';
+import {BufferLike, sha3hash} from './utilities';
+
+export class LibraAccount {
+  public static fromSecretKey(secretKey: BufferLike) {
+    return new LibraAccount(keyPairFromSecret(secretKey));
+  }
+
+  public static fromSeed(seed: BufferLike, index: number | BigInt | Buffer) {
+    return new LibraAccount(generateKeyPair(seed, index));
+  }
+
+  constructor(public readonly keyPair: eddsa.KeyPair) {}
+
+  get publicKey() {
+    return this.keyPair.getPublic('hex');
+  }
+
+  get secretKey() {
+    return this.keyPair.getSecret('hex');
+  }
+
+  get address() {
+    return sha3hash(this.keyPair.getPublic()).toString('hex');
+  }
+
+  get authKeyPrefix() {
+    return this.address.slice(0, 32);
+  }
+
+  get shortAddress() {
+    return this.address.slice(-32);
+  }
+
+  // NOTE: not working :(
+  // might be able to port over the jLibra implementation
+  // see: https://github.com/ketola/jlibra/blob/master/jlibra-core/src/test/java/dev/jlibra/serialization/lcs/LCSSerializerTest.java
+  // signTransactionData(
+  //   toAddress: BufferLike,
+  //   amount: number,
+  //   sequenceNumber: number,
+  //   maxGasAmount?: number,
+  //   gasUnitPrice?: number,
+  //   expiration?: number,
+  // ) {
+  //   return signTransactionData(
+  //     this.keyPair,
+  //     toAddress,
+  //     amount,
+  //     sequenceNumber,
+  //     maxGasAmount,
+  //     gasUnitPrice,
+  //     expiration,
+  //   ).toString('hex');
+  // }
+
+  toString() {
+    return [
+      `     Secret Key: ${this.secretKey}`,
+      `     Public Key: ${this.publicKey}`,
+      `       Auth Key: ${this.address}`,
+      `  Short Address: ${this.shortAddress}`,
+      `Auth Key Prefix: ${this.authKeyPrefix}`,
+    ].join('\n');
+  }
+}

--- a/packages/libra-web-wallet-utils/src/LibraWallet.ts
+++ b/packages/libra-web-wallet-utils/src/LibraWallet.ts
@@ -1,0 +1,44 @@
+import {
+  generateSeedPhrase,
+  generateSeedKey,
+  SeedKeyOptions,
+} from './generators';
+import {LibraAccount} from './LibraAccount';
+
+export class LibraWallet<Phrase = never> {
+  public static generate(options?: SeedKeyOptions) {
+    const phrase = generateSeedPhrase();
+
+    return new LibraWallet<string>(
+      generateSeedKey(phrase, options).toString('hex'),
+      phrase,
+    );
+  }
+
+  public readonly accounts: Record<number, LibraAccount> = {};
+
+  constructor(
+    public readonly seed: string,
+    private readonly _phrase?: string,
+  ) {}
+
+  get phrase(): Phrase {
+    return this._phrase as any;
+  }
+
+  getAccount(index: number) {
+    if (this.accounts[index] == null) {
+      this.accounts[index] = LibraAccount.fromSeed(this.seed, index);
+    }
+
+    return this.accounts[index];
+  }
+
+  toString() {
+    Object.entries(this.accounts)
+      .map(([index, account]) =>
+        [`Account #${index}`, account.toString()].join('\n'),
+      )
+      .join('\n\n');
+  }
+}

--- a/packages/libra-web-wallet-utils/src/generators/constants.ts
+++ b/packages/libra-web-wallet-utils/src/generators/constants.ts
@@ -1,0 +1,10 @@
+export const hashDigest = 'sha3-256';
+export const keyIterations = 2048;
+export const keyLength = 32;
+export const addressLength = 32;
+
+export const derivedKeySalt = 'LIBRA WALLET: derived key$';
+export const masterKeySalt = 'LIBRA WALLET: master key salt$';
+export const mnemonicSalt = 'LIBRA WALLET: mnemonic salt prefix$';
+export const rawTransactionSalt = 'RawTransaction@@$$LIBRA$$@@';
+export const seedKeySalt = 'LIBRA';

--- a/packages/libra-web-wallet-utils/src/generators/index.ts
+++ b/packages/libra-web-wallet-utils/src/generators/index.ts
@@ -1,0 +1,4 @@
+export * from './constants';
+export * from './keyPair';
+export * from './seedKey';
+export * from './seedPhrase';

--- a/packages/libra-web-wallet-utils/src/generators/keyPair.ts
+++ b/packages/libra-web-wallet-utils/src/generators/keyPair.ts
@@ -1,0 +1,49 @@
+import {eddsa as Eddsa} from 'elliptic';
+// eslint-disable-next-line @typescript-eslint/camelcase
+import {expand, extract, hash_length} from 'futoin-hkdf';
+
+import {
+  asUInt64LE,
+  BufferLike,
+  getBuffer,
+  GetBufferOptions,
+} from '../utilities';
+
+import {
+  derivedKeySalt,
+  hashDigest,
+  keyLength,
+  masterKeySalt,
+} from './constants';
+
+export const dsaHashLength = hash_length(hashDigest);
+
+export function keyPairFromSecret(secretKey: BufferLike) {
+  return new Eddsa('ed25519').keyFromSecret(
+    getBuffer(secretKey, {encoding: 'hex'}),
+  );
+}
+
+export function generateKeyPair(
+  seedKey: BufferLike,
+  index: number | BigInt | Buffer = 0,
+  options: GetBufferOptions = {encoding: 'hex'},
+) {
+  return keyPairFromSecret(
+    expand(
+      hashDigest,
+      dsaHashLength,
+      extract(
+        hashDigest,
+        dsaHashLength,
+        getBuffer(seedKey, options),
+        getBuffer(masterKeySalt),
+      ),
+      keyLength,
+      Buffer.concat([
+        Buffer.from(derivedKeySalt),
+        Buffer.isBuffer(index) ? index : asUInt64LE(index),
+      ]),
+    ),
+  );
+}

--- a/packages/libra-web-wallet-utils/src/generators/seedKey.ts
+++ b/packages/libra-web-wallet-utils/src/generators/seedKey.ts
@@ -1,0 +1,35 @@
+import {pbkdf2Sync} from 'pbkdf2';
+
+import {BufferLike, getBuffer} from '../utilities';
+
+import {
+  hashDigest,
+  keyIterations,
+  keyLength,
+  mnemonicSalt,
+  seedKeySalt,
+} from './constants';
+import {generateSeedPhrase} from './seedPhrase';
+
+export interface SeedKeyOptions {
+  salt?: string | Buffer;
+  iterations?: number;
+  length?: number;
+}
+
+export function generateSeedKey(
+  phrase?: BufferLike,
+  {
+    salt = seedKeySalt,
+    iterations = keyIterations,
+    length = keyLength,
+  }: SeedKeyOptions = {},
+) {
+  return pbkdf2Sync(
+    getBuffer(phrase || generateSeedPhrase()),
+    getBuffer(`${mnemonicSalt}${salt}`),
+    iterations,
+    length,
+    hashDigest,
+  );
+}

--- a/packages/libra-web-wallet-utils/src/generators/seedPhrase.ts
+++ b/packages/libra-web-wallet-utils/src/generators/seedPhrase.ts
@@ -1,0 +1,15 @@
+import {generateMnemonic} from 'bip39';
+
+export interface SeedPhraseOptions {
+  strength?: number;
+  rng?: (size: number) => Buffer;
+  wordlist?: string[];
+}
+
+export function generateSeedPhrase({
+  strength = 256,
+  rng,
+  wordlist,
+}: SeedPhraseOptions = {}) {
+  return generateMnemonic(strength, rng, wordlist);
+}

--- a/packages/libra-web-wallet-utils/src/index.ts
+++ b/packages/libra-web-wallet-utils/src/index.ts
@@ -1,0 +1,5 @@
+export * from './LibraAccount';
+export * from './LibraWallet';
+export * from './generators';
+export * from './transaction';
+export * from './utilities';

--- a/packages/libra-web-wallet-utils/src/proto/index.ts
+++ b/packages/libra-web-wallet-utils/src/proto/index.ts
@@ -1,0 +1,1 @@
+export {RawTransaction, SignedTransaction} from './transaction';

--- a/packages/libra-web-wallet-utils/src/proto/transaction.proto
+++ b/packages/libra-web-wallet-utils/src/proto/transaction.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package types;
+
+// A generic structure that describes a transaction that a client submits
+message RawTransaction {
+    // Sender's account address
+    bytes sender_account = 1;
+    // Sequence number of this transaction corresponding to sender's account.
+    uint64 sequence_number = 2 [jstype = JS_STRING];
+    // The transaction script to execute.
+    Program payload =  3;
+    // Maximal total gas specified by wallet to spend for this transaction.
+    uint64 max_gas_amount = 4 [jstype = JS_STRING];
+    // The price to be paid for each unit of gas.
+    uint64 gas_unit_price = 5 [jstype = JS_STRING];
+    // Expiration time for this transaction.  If storage is queried and
+    // the time returned is greater than or equal to this time and this
+    // transaction has not been included, you can be certain that it will
+    // never be included.
+    // If set to 0, there will be no expiration time
+    uint64 expiration_time = 6 [jstype = JS_STRING];
+}
+
+// The code for the transaction to execute
+message Program {
+    bytes code = 1;
+    repeated TransactionArgument arguments = 2;
+    repeated bytes modules = 3;
+}
+
+// An argument to the transaction if the transaction takes arguments
+message TransactionArgument {
+    enum ArgType {
+        U64 = 0;
+        ADDRESS = 1;
+        STRING = 2;
+        BYTEARRAY = 3;
+    }
+    ArgType type = 1;
+    bytes data = 2;
+}
+
+message Authenticator {
+    // public key that corresponds to RawTransaction::sender_account
+    bytes sender_public_key = 1 [jstype = JS_STRING];
+    // signature for the hash
+    bytes sender_signature = 2 [jstype = JS_STRING];
+}
+
+// A generic structure that represents signed RawTransaction
+message SignedTransaction {
+    // The serialized Protobuf bytes for RawTransaction, for which the signature
+    // was signed. Protobuf doesn't guarantee the serialized bytes is canonical
+    // across different language implementations, but for our use cases for
+    // transaction it is not necessary because the client is the only one to
+    // produce this bytes, which is then persisted in storage.
+    bytes raw_txn_bytes = 1 [jstype = JS_STRING];
+    Authenticator authenticator = 2;
+}

--- a/packages/libra-web-wallet-utils/src/proto/transaction.proto.json
+++ b/packages/libra-web-wallet-utils/src/proto/transaction.proto.json
@@ -1,0 +1,121 @@
+{
+  "nested": {
+    "types": {
+      "nested": {
+        "RawTransaction": {
+          "fields": {
+            "senderAccount": {
+              "type": "bytes",
+              "id": 1
+            },
+            "sequenceNumber": {
+              "type": "uint64",
+              "id": 2,
+              "options": {
+                "jstype": "JS_STRING"
+              }
+            },
+            "payload": {
+              "type": "Program",
+              "id": 3
+            },
+            "maxGasAmount": {
+              "type": "uint64",
+              "id": 4,
+              "options": {
+                "jstype": "JS_STRING"
+              }
+            },
+            "gasUnitPrice": {
+              "type": "uint64",
+              "id": 5,
+              "options": {
+                "jstype": "JS_STRING"
+              }
+            },
+            "expirationTime": {
+              "type": "uint64",
+              "id": 6,
+              "options": {
+                "jstype": "JS_STRING"
+              }
+            }
+          }
+        },
+        "Program": {
+          "fields": {
+            "code": {
+              "type": "bytes",
+              "id": 1
+            },
+            "arguments": {
+              "rule": "repeated",
+              "type": "TransactionArgument",
+              "id": 2
+            },
+            "modules": {
+              "rule": "repeated",
+              "type": "bytes",
+              "id": 3
+            }
+          }
+        },
+        "TransactionArgument": {
+          "fields": {
+            "type": {
+              "type": "ArgType",
+              "id": 1
+            },
+            "data": {
+              "type": "bytes",
+              "id": 2
+            }
+          },
+          "nested": {
+            "ArgType": {
+              "values": {
+                "U64": 0,
+                "ADDRESS": 1,
+                "STRING": 2,
+                "BYTEARRAY": 3
+              }
+            }
+          }
+        },
+        "Authenticator": {
+          "fields": {
+            "senderPublicKey": {
+              "type": "bytes",
+              "id": 1,
+              "options": {
+                "jstype": "JS_STRING"
+              }
+            },
+            "senderSignature": {
+              "type": "bytes",
+              "id": 2,
+              "options": {
+                "jstype": "JS_STRING"
+              }
+            }
+          }
+        },
+        "SignedTransaction": {
+          "fields": {
+            "rawTxnBytes": {
+              "type": "bytes",
+              "id": 1,
+              "options": {
+                "jstype": "JS_STRING"
+              }
+            },
+            "authenticator": {
+              "type": "Authenticator",
+              "id": 2
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/libra-web-wallet-utils/src/proto/transaction.ts
+++ b/packages/libra-web-wallet-utils/src/proto/transaction.ts
@@ -1,0 +1,10 @@
+import {Root} from 'protobufjs';
+
+// create the json via
+// protobufjs.parse(protoContent).root.toJSON()
+import proto from './transaction.proto.json';
+// const proto = require('./transaction.proto.json');
+
+export const root = Root.fromJSON(proto);
+export const RawTransaction = root.lookupType('types.RawTransaction');
+export const SignedTransaction = root.lookupType('types.SignedTransaction');

--- a/packages/libra-web-wallet-utils/src/test/e2e.test.ts
+++ b/packages/libra-web-wallet-utils/src/test/e2e.test.ts
@@ -1,0 +1,17 @@
+import {LibraWallet} from '../../dist/src/LibraWallet';
+
+describe('e2e', () => {
+  it('can generate a wallet with a phrase', () => {
+    const wallet = LibraWallet.generate();
+
+    expect(wallet.phrase).toBeDefined();
+  });
+
+  it('can initialize a wallet from a seed', () => {
+    const seed =
+      '9992ee9735d81d37b121ed18c8948f5750e4d4c20e44e230d533b99db5be08c9';
+    const wallet = new LibraWallet(seed);
+
+    expect(wallet.seed).toBe(seed);
+  });
+});

--- a/packages/libra-web-wallet-utils/src/transaction.ts
+++ b/packages/libra-web-wallet-utils/src/transaction.ts
@@ -1,0 +1,154 @@
+import {eddsa} from 'elliptic';
+
+import {rawTransactionSalt} from './generators';
+import {RawTransaction, SignedTransaction} from './proto';
+import {asUInt64LE, BufferLike, getBuffer, sha3hash} from './utilities';
+
+export enum LibraProgramArgumentType {
+  U64 = 0,
+  Address = 1,
+  String = 2,
+  ByteArray = 3,
+}
+
+export interface LibraProgramArgument {
+  type: LibraProgramArgumentType;
+  value: Buffer;
+}
+
+export interface LibraProgram {
+  code: Buffer;
+  arguments: LibraProgramArgument[];
+}
+
+export interface LibraTransferTransaction {
+  senderAccount: Buffer;
+  sequenceNumber: number;
+  payload: LibraProgram;
+  maxGasAmount: number;
+  gasUnitPrice: number;
+  expirationTime: number;
+}
+
+export interface SignedRawTransaction {
+  rawTxnBytes: Buffer;
+  senderPublicKey: Buffer;
+  senderSignature: Buffer;
+}
+
+// base64 encoded binary for the compiled peer_to_peer.move script
+// see: https://developers.libra.org/docs/run-move-locally#compile-and-publish-move-modules (for compilation)
+// similar to the script in https://github.com/libra/libra/blob/master/language/stdlib/transaction_scripts/peer_to_peer.move
+// for more details
+// see: https://github.com/libra/libra/blob/master/language/stdlib/transaction_scripts/doc/peer_to_peer.md
+export const p2pTranasctionCode =
+  'TElCUkFWTQoBAAcBSgAAAAQAAAADTgAAAAYAAAAMVAAAAAYAAAANWgAAAAYAAAAFYAAAACkAAAAEiQAAACAAAAAHqQAAAA4AAAAAAAABAAIAAQMAAgACBAIAAwADAgQCBjxTRUxGPgxMaWJyYUFjY291bnQEbWFpbg9wYXlfZnJvbV9zZW5kZXIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAgEEAAwADAERAQAC';
+// pre-compute the salt hash since we are just packing it into the wire format anyways
+export const rawTransactionSaltHash = sha3hash(rawTransactionSalt);
+
+export function generateTransferTransactionScript(
+  amount: number | BigInt,
+  address: BufferLike,
+): LibraProgram {
+  return {
+    arguments: [
+      {
+        type: LibraProgramArgumentType.Address,
+        value: getBuffer(address, {encoding: 'hex'}),
+      },
+      {
+        type: LibraProgramArgumentType.U64,
+        value: asUInt64LE(amount),
+      },
+    ],
+    code: getBuffer(p2pTranasctionCode, {encoding: 'base64'}),
+  };
+}
+
+export function generateTransferTransaction(
+  amount: number | BigInt,
+  receiverAddress: BufferLike,
+  senderAddress: BufferLike,
+  sequenceNumber: number,
+  maxGasAmount = 1000000,
+  gasUnitPrice = 0,
+  expiration = 300,
+): LibraTransferTransaction {
+  return {
+    senderAccount: getBuffer(senderAddress, {encoding: 'hex'}),
+    sequenceNumber,
+    payload: generateTransferTransactionScript(amount, receiverAddress),
+    maxGasAmount,
+    gasUnitPrice,
+    expirationTime: Math.floor(new Date().getTime() / 1000) + expiration,
+  };
+}
+
+export function encodeTransferTransaction(
+  transaction: LibraTransferTransaction,
+): Buffer {
+  return Buffer.from(
+    RawTransaction.encode(RawTransaction.create(transaction)).finish(),
+  );
+}
+
+export function signRawTransaction(
+  rawTxn: BufferLike,
+  keyPair: eddsa.KeyPair,
+): SignedRawTransaction {
+  const rawTxnBytes = getBuffer(rawTxn, {encoding: 'hex'});
+
+  return {
+    rawTxnBytes,
+    senderPublicKey: keyPair.getPublic(),
+    senderSignature: keyPair
+      .sign(sha3hash(rawTransactionSaltHash, rawTxnBytes))
+      .toBytes(),
+  };
+}
+
+export function encodeSignedTransaction(
+  signedRawTransaction: SignedRawTransaction,
+) {
+  return Buffer.from(
+    SignedTransaction.encode(
+      SignedTransaction.create(signedRawTransaction),
+    ).finish(),
+  );
+}
+
+export function signTransferTrasaction(
+  keyPair: eddsa.KeyPair,
+  transaction: LibraTransferTransaction,
+) {
+  return encodeSignedTransaction(
+    signRawTransaction(encodeTransferTransaction(transaction), keyPair),
+  );
+}
+
+export function signTransactionData(
+  keyPair: eddsa.KeyPair,
+  toAddress: BufferLike,
+  amount: number,
+  sequenceNumber: number,
+  maxGasAmount?: number,
+  gasUnitPrice?: number,
+  expiration?: number,
+) {
+  return encodeSignedTransaction(
+    signRawTransaction(
+      encodeTransferTransaction(
+        generateTransferTransaction(
+          amount,
+          toAddress,
+          sha3hash(keyPair.getPublic()),
+          sequenceNumber,
+          maxGasAmount,
+          gasUnitPrice,
+          expiration,
+        ),
+      ),
+      keyPair,
+    ),
+  );
+}

--- a/packages/libra-web-wallet-utils/src/utilities/asUInt64LE.ts
+++ b/packages/libra-web-wallet-utils/src/utilities/asUInt64LE.ts
@@ -1,0 +1,7 @@
+export function asUInt64LE(index: number | BigInt) {
+  const buffer = Buffer.alloc(8);
+
+  buffer.writeBigUInt64LE(BigInt(index));
+
+  return buffer;
+}

--- a/packages/libra-web-wallet-utils/src/utilities/getBuffer.ts
+++ b/packages/libra-web-wallet-utils/src/utilities/getBuffer.ts
@@ -1,0 +1,30 @@
+export type BufferLike = Buffer | string | Uint8Array;
+
+export interface GetBufferOptions {
+  encoding?: BufferEncoding;
+  normalizeForm?: string;
+}
+
+export function getBuffer(
+  input: BufferLike,
+  options?: GetBufferOptions,
+): Buffer;
+export function getBuffer(
+  input?: BufferLike,
+  options?: GetBufferOptions,
+): Buffer | undefined;
+export function getBuffer(
+  input?: BufferLike,
+  {encoding = 'utf8', normalizeForm = 'NFKD'}: GetBufferOptions = {},
+) {
+  if (!input || Buffer.isBuffer(input)) {
+    return input;
+  }
+
+  if (typeof input === 'string') {
+    return Buffer.from(input.normalize(normalizeForm), encoding);
+  }
+
+  // assume byte array
+  return Buffer.from(input);
+}

--- a/packages/libra-web-wallet-utils/src/utilities/index.ts
+++ b/packages/libra-web-wallet-utils/src/utilities/index.ts
@@ -1,0 +1,3 @@
+export * from './asUInt64LE';
+export * from './getBuffer';
+export * from './sha3hash';

--- a/packages/libra-web-wallet-utils/src/utilities/sha3hash.ts
+++ b/packages/libra-web-wallet-utils/src/utilities/sha3hash.ts
@@ -1,0 +1,9 @@
+import {SHA3} from 'sha3';
+
+import {BufferLike, getBuffer} from './getBuffer';
+
+export function sha3hash(...messages: BufferLike[]) {
+  return new SHA3(256)
+    .update(Buffer.concat(messages.map((message) => getBuffer(message))))
+    .digest();
+}

--- a/packages/libra-web-wallet-utils/tsconfig.json
+++ b/packages/libra-web-wallet-utils/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig_base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "rootDir": "."
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "files": [],
   "include": [],
-  "references": [{"path": "./libra-rpc-graphql"}]
+  "references": [
+    {"path": "./libra-rpc-graphql"},
+    {"path": "./libra-web-wallet-utils"}
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,6 +1244,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bn.js@*":
+  version "4.11.6"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
+  integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*", "@types/body-parser@1.19.0":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
@@ -1285,6 +1292,13 @@
   integrity sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==
   dependencies:
     "@types/express" "*"
+
+"@types/elliptic@^6.0.0":
+  version "6.4.12"
+  resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.12.tgz#e8add831f9cc9a88d9d84b3733ff669b68eaa124"
+  integrity sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==
+  dependencies:
+    "@types/bn.js" "*"
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -1459,7 +1473,7 @@
     "@types/interpret" "*"
     "@types/node" "*"
 
-"@types/long@^4.0.0":
+"@types/long@^4.0.0", "@types/long@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
@@ -1487,10 +1501,27 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.5.tgz#3d03acd3b3414cf67faf999aed11682ed121f22b"
   integrity sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==
 
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
 "@types/node@^10.1.0":
   version "10.17.24"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.24.tgz#c57511e3a19c4b5e9692bb2995c40a3a52167944"
   integrity sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA==
+
+"@types/node@^13.7.0":
+  version "13.13.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.9.tgz#79df4ae965fb76d31943b54a6419599307a21394"
+  integrity sha512-EPZBIGed5gNnfWCiwEIwTE2Jdg4813odnG8iNPMQGrqVxrI+wL68SPtPeCX+ZxGBaA6pKAVc6jaKgP/Q0QzfdQ==
+
+"@types/pbkdf2@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/pbkdf2/-/pbkdf2-3.0.0.tgz#5d9ca5f12a78a08cc89ad72883ad4a30af359229"
+  integrity sha512-6J6MHaAlBJC/eVMy9jOwj9oHaprfutukfW/Dyt0NEnpQ/6HN6YQrpvLwzWdWDeWZIdenjGHlbYDzyEODO5Z+2Q==
+  dependencies:
+    "@types/node" "*"
 
 "@types/qs@*":
   version "6.9.3"
@@ -2292,6 +2323,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.0.2:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -2323,6 +2359,21 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bip39@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.2.tgz#2baf42ff3071fc9ddd5103de92e8f80d9257ee32"
+  integrity sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
+
+bn.js@^4.4.0:
+  version "4.11.9"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
+  integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
 body-parser@1.19.0, body-parser@^1.18.3:
   version "1.19.0"
@@ -2371,6 +2422,11 @@ braces@^3.0.1:
   dependencies:
     fill-range "^7.0.1"
 
+brorand@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
+
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
@@ -2411,6 +2467,14 @@ buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.5.0.tgz#9c3caa3d623c33dd1c7ef584b89b88bf9c9bc1ce"
+  integrity sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 busboy@^0.3.1:
   version "0.3.1"
@@ -2609,6 +2673,14 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+cipher-base@^1.0.1, cipher-base@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -3065,6 +3137,29 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+create-hash@^1.1.0, create-hash@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
+
+create-hmac@^1.1.4:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
+  dependencies:
+    cipher-base "^1.0.3"
+    create-hash "^1.1.0"
+    inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 cross-fetch@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
@@ -3406,6 +3501,19 @@ element-closest@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-3.0.2.tgz#3814a69a84f30e48e63eaf57341f4dbf4227d2aa"
   integrity sha512-JxKQiJKX0Zr5Q2/bCaTx8P+UbfyMET1OQd61qu5xQFeWr1km3fGaxelSJtnfT27XQ5Uoztn2yIyeamAc/VX13g==
+
+elliptic@^6.0.0:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
 
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
@@ -4288,6 +4396,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+futoin-hkdf@^1.0.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/futoin-hkdf/-/futoin-hkdf-1.3.2.tgz#cd9a09153e3db7d166b9717f872991a4950430cd"
+  integrity sha512-3EVi3ETTyJg5PSXlxLCaUVVn0pSbDf62L3Gwxne7Uq+d8adOSNWQAad4gg7WToHkcgnCJb3Wlb1P8r4Evj4GPw==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -4685,6 +4798,23 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash-base@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
+  dependencies:
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    safe-buffer "^5.2.0"
+
+hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 header-case@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/header-case/-/header-case-1.0.1.tgz#9535973197c144b09613cd65d317ef19963bd02d"
@@ -4692,6 +4822,15 @@ header-case@^1.0.0:
   dependencies:
     no-case "^2.2.0"
     upper-case "^1.1.3"
+
+hmac-drbg@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
+  dependencies:
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"
@@ -4779,6 +4918,11 @@ iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 ignore-walk@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
@@ -4850,7 +4994,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -6170,6 +6314,15 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -6298,6 +6451,16 @@ min-document@^2.19.0:
   integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
+
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
+minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -6969,6 +7132,17 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pbkdf2@^3.0.0, pbkdf2@^3.0.9:
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
+  integrity sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
+  dependencies:
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -7139,6 +7313,25 @@ prop-types@^15.6.1, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+protobufjs@^6.0.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.9.0.tgz#c08b2bf636682598e6fabbf0edb0b1256ff090bd"
+  integrity sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" "^13.7.0"
+    long "^4.0.0"
+
 proxy-addr@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
@@ -7189,6 +7382,13 @@ quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
+
+randombytes@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -7317,6 +7517,15 @@ readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@~2.3.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -7608,6 +7817,14 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+ripemd160@^2.0.0, ripemd160@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -7647,7 +7864,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -7774,13 +7991,20 @@ setprototypeof@1.1.1:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
-sha.js@^2.4.11:
+sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+sha3@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/sha3/-/sha3-2.1.2.tgz#76f404e401d17ca1d23d8458a3790d57f0671bac"
+  integrity sha512-agYUtkzMsdFTQkM3ECyt6YW0552fyEb0tYZkl7olurS1Vg2Ms5+2SdF4VFPC1jnwtiXMb8b0fSyuAGZh+q2mAw==
+  dependencies:
+    buffer "5.5.0"
 
 shallowequal@^1.1.0:
   version "1.1.0"
@@ -8104,6 +8328,13 @@ string.prototype.trimstart@^1.0.0:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -8476,7 +8707,7 @@ ts-node-dev@^1.0.0-pre.44:
     ts-node "*"
     tsconfig "^7.0.0"
 
-ts-node@*:
+ts-node@*, ts-node@^8.0.0:
   version "8.10.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
   integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
@@ -8675,7 +8906,7 @@ user-home@^1.1.1:
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
   integrity sha1-K1viOjK2Onyd640PKNSFcko98ZA=
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
## Description

adding new package: `libra-web-wallet-utils` which will allow creation and introspection of wallet and account details.

## Tophatting

use the cli tool to test out the functions of this package

- generate a seed: `yarn wallet seed`
- generate an account: `yarn wallet account 53ba07fec3cf939a62677fc508fd11d90e65d81c7ce26fc15cdf449333e62b12 1` (2nd account, zero indexed, for the provided seed)
- `transfer`: `yarn wallet transfer 8623a75c9002adf035402cae70fd48a32317c8570414ddab1ab5448a42366e57 705307883a9798cce500886efdcd303fd5cfdb35945dbd1ad852d6390460397e 100 0` (note that this does not serialize properly yet)