### PR TITLE
adding missing exports for client, link, and types

### DIFF
--- a/packages/libra-rpc-graphql/CHANGELOG.md
+++ b/packages/libra-rpc-graphql/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Adding all the missing exports (`client`, `link`, `types`) ([#13](https://github.com/Shopify/libra-web-tools/pull/13))
+
 ## [2.0.0]
 
 ### Changed

--- a/packages/libra-rpc-graphql/scripts/server.ts
+++ b/packages/libra-rpc-graphql/scripts/server.ts
@@ -6,7 +6,7 @@ import {ApolloServer, PlaygroundRenderPageOptions} from 'apollo-server-express';
 import {print} from 'graphql';
 import gql from 'graphql-tag';
 
-import {createContext, schema} from '../src/link';
+import {createContext, createSchema} from '../src/link';
 import {LibraNetwork} from '../src/types';
 
 const {HOST = 'localhost', PORT = 8000} = process.env;
@@ -266,7 +266,7 @@ const server = new ApolloServer({
   playground: {
     tabs,
   },
-  schema,
+  schema: createSchema(),
 });
 server.applyMiddleware({app, path});
 

--- a/packages/libra-rpc-graphql/src/index.ts
+++ b/packages/libra-rpc-graphql/src/index.ts
@@ -1,2 +1,5 @@
+export * from './client';
 export * from './graphql';
+export * from './link';
 export * from './resolvers';
+export * from './types';

--- a/packages/libra-rpc-graphql/src/link.ts
+++ b/packages/libra-rpc-graphql/src/link.ts
@@ -51,15 +51,6 @@ export function addDumpFieldToSchema(schema: GraphQLSchema) {
   }, schema);
 }
 
-export const schema = addDumpFieldToSchema(
-  addFieldRenameResolversToSchema(
-    makeExecutableSchema({
-      typeDefs,
-      resolvers,
-    }),
-  ),
-);
-
 export function createContext(target: string): Context {
   return {
     rpc: createLibraRpc(target),
@@ -67,11 +58,22 @@ export function createContext(target: string): Context {
   };
 }
 
+export function createSchema() {
+  return addDumpFieldToSchema(
+    addFieldRenameResolversToSchema(
+      makeExecutableSchema({
+        typeDefs,
+        resolvers,
+      }),
+    ),
+  );
+}
+
 export function createApolloLink(target: string) {
   return ApolloLink.from([
     new SchemaLink({
       context: createContext(target),
-      schema,
+      schema: createSchema(),
     }),
   ]);
 }

--- a/packages/libra-web-wallet-utils/CHANGELOG.md
+++ b/packages/libra-web-wallet-utils/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+<!-- ## [Unreleased] -->
+
 ## [2.0.0]
 
 ### Changed


### PR DESCRIPTION
## Description

- `libra-rpc-graphql` wasn't exporting anything from the `client`, `link`, or `types` modules.
- refactored `link` to add a new `createSchema` function to create the composed schema with dynamic fields

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
