### PR TITLE
making it easier to extend the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "generate": "plop",
     "generate:package": "plop package && yarn plop docs",
     "tophat": "tophat",
-    "playground": "yarn --cwd packages/libra-rpc-graphql run start",
+    "preplayground": "yarn run build",
+    "playground": "yarn --cwd packages/libra-rpc-graphql run playground",
     "wallet": "yarn --cwd packages/libra-web-wallet-utils run wallet",
     "start": "yarn run playground"
   },

--- a/packages/libra-rpc-graphql/CHANGELOG.md
+++ b/packages/libra-rpc-graphql/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Added ability to inject a express app to enable custom configuration ([#16](https://github.com/Shopify/libra-web-tools/pull/16))
 
 ## [2.2.0]
 
 ### Added
 
-- added a new `server` module to simplify creating a playground server with `startExpress()` ([#14](https://github.com/Shopify/libra-web-tools/pull/14))
+- Added a new `server` module to simplify creating a playground server with `startExpress()` ([#14](https://github.com/Shopify/libra-web-tools/pull/14))
 
 ## [2.1.0]
 

--- a/packages/libra-rpc-graphql/package.json
+++ b/packages/libra-rpc-graphql/package.json
@@ -16,8 +16,10 @@
     "introspectify:server": "yarn run introspectify src/graphql/schema.json",
     "preserver": "yarn run introspectify:server",
     "server": "ts-node scripts/server.ts",
-    "prestart": "yarn run introspectify:server",
-    "start": "ts-node-dev --respawn --transpile-only scripts/server.ts"
+    "prestart": "yarn run build && yarn run preserver",
+    "start": "yarn run playground",
+    "preplayground": "yarn run preserver",
+    "playground": "ts-node-dev --respawn --transpile-only scripts/server.ts"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/libra-rpc-graphql/scripts/server.ts
+++ b/packages/libra-rpc-graphql/scripts/server.ts
@@ -1,9 +1,14 @@
 /* eslint-env node */
 /* eslint-disable no-process-env */
 
-import {startExpress} from '../src/server';
+import express from 'express';
+
+import {start} from '../src/server';
 
 const {HOST: host, PORT} = process.env;
 const [network] = process.argv.slice(2);
+const app = express();
 
-startExpress({host, port: Number(PORT) || undefined, network, tabs: true});
+app.get('/services/ping', (_req, res) => res.json('OK'));
+
+start({app, host, port: Number(PORT) || undefined, network, tabs: true});


### PR DESCRIPTION
## Description

This allows the server to be started with an existing express instance so we can setup custom routes. I also adjusted the scripts a bit to better support a fresh checkout.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)

This is kind of a breaking change, but the server is not part of the actual API so i'm just tagging it as a minor bump.

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
