### PR TITLE
adding account state details to wallet test query

### DIFF
--- a/packages/libra-rpc-graphql/CHANGELOG.md
+++ b/packages/libra-rpc-graphql/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Adding account state to test query ([#18](https://github.com/Shopify/libra-web-tools/pull/18))
 
 ## [2.3.1]
 

--- a/packages/libra-rpc-graphql/src/server/graphql/LibraTestQuery.ts
+++ b/packages/libra-rpc-graphql/src/server/graphql/LibraTestQuery.ts
@@ -12,6 +12,15 @@ export default gql`
         publicKey
         authKey
         address
+        state {
+          sequenceNumber
+          isFrozen
+          balances {
+            amount
+            currency
+          }
+          role
+        }
       }
     }
     received: accountState(address: $address) {


### PR DESCRIPTION
## Description

This adds some basic visibility to the account state for the wallet test query:

- `sequenceNumber`
- `isFrozen`
- `balances`
- `role`

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
