### PR TITLE
only inject RPC metadata on non-null results

### DIFF
--- a/packages/libra-rpc-graphql/CHANGELOG.md
+++ b/packages/libra-rpc-graphql/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- RPC metadata now only appended to non-null results ([#20](https://github.com/Shopify/libra-web-tools/pull/20))
 
 ## [2.5.0]
 

--- a/packages/libra-rpc-graphql/src/client.ts
+++ b/packages/libra-rpc-graphql/src/client.ts
@@ -57,7 +57,9 @@ export function createLibraRpc(target: string) {
       if ('result' in data && typeof data.result === 'object') {
         const {result, ...rpcMetadata} = data;
 
-        result._rpcMetadata = rpcMetadata;
+        if (result) {
+          result._rpcMetadata = rpcMetadata;
+        }
 
         return result;
       }


### PR DESCRIPTION
## Description

When the RPC result was null we were still trying to inject the `_rpcMetadata` field. This change will prevent that from happening, `_rpcMetadata` will only be available when there is a non-null result.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
