### PR TITLE
adding new libra-rpc-graphql-server package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Without `dev` we can instead run `yarn && yarn start` to get up and running.
 | package |     |     |
 | ------- | --- | --- |
 | libra-rpc-graphql | [directory](packages/libra-rpc-graphql) | [![npm version](https://badge.fury.io/js/%40shopify%2Flibra-rpc-graphql.svg)](https://badge.fury.io/js/%40shopify%2Flibra-rpc-graphql) |
+| libra-rpc-graphql-server | [directory](packages/libra-rpc-graphql-server) | [![npm version](https://badge.fury.io/js/%40shopify%2Flibra-rpc-graphql-server.svg)](https://badge.fury.io/js/%40shopify%2Flibra-rpc-graphql-server) |
 | libra-web-wallet-utils | [directory](packages/libra-web-wallet-utils) | [![npm version](https://badge.fury.io/js/%40shopify%2Flibra-web-wallet-utils.svg)](https://badge.fury.io/js/%40shopify%2Flibra-web-wallet-utils) |
 
 ## Want to contribute?

--- a/packages/libra-rpc-graphql-server/CHANGELOG.md
+++ b/packages/libra-rpc-graphql-server/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `@shopify/libra-rpc-graphql-server` package

--- a/packages/libra-rpc-graphql-server/README.md
+++ b/packages/libra-rpc-graphql-server/README.md
@@ -1,0 +1,50 @@
+# `@shopify/libra-rpc-graphql-server`
+
+[![Build Status](https://travis-ci.org/Shopify/web-tools.svg?branch=master)](https://travis-ci.org/Shopify/web-tools)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Flibra-rpc-graphql-server.svg)](https://badge.fury.io/js/%40shopify%2Flibra-rpc-graphql-server.svg)
+
+Libra GraphQL Playground server
+
+## Installation
+
+```bash
+$ yarn add @shopify/libra-rpc-graphql-server
+```
+
+## Usage
+
+You can build a new express server by using `createSchema` and `createContext` from [`@shopify/libra-rpc-graphql`](https://github.com/Shopify/libra-web-tools/blob/master/packages/libra-rpc-graphql)
+
+```tsx
+/* eslint-env node */
+/* eslint-disable no-process-env */
+
+import express from 'express';
+
+import {
+  createContext,
+  createSchema,
+  LibraNetwork,
+} from '@shopify/libra-rpc-graphql';
+import {
+  applyMiddleware,
+  createServer,
+  defaults,
+} from '@shopify/libra-rpc-graphql-server';
+
+const port = 8080;
+const path = defaults.path;
+const app = applyMiddleware(
+  createServer(createSchema(), {
+    context: createContext(LibraNetwork.Testnet),
+    path,
+    tabs: {minter: true},
+  }),
+);
+
+app.listen(port, () => {
+  console.log(
+    `🚀  GraphQL playground running at http://localhost:${port}${path}`,
+  );
+});
+```

--- a/packages/libra-rpc-graphql-server/package.json
+++ b/packages/libra-rpc-graphql-server/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@shopify/libra-rpc-graphql-server",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Libra GraphQL Playground Apollo server running on express",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc --p tsconfig.json"
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org"
+  },
+  "author": "Shopify Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Shopify/libra-web-tools.git",
+    "directory": "packages/libra-rpc-graphql-server"
+  },
+  "bugs": {
+    "url": "https://github.com/Shopify/libra-web-tools/issues"
+  },
+  "homepage": "https://github.com/Shopify/libra-web-tools/blob/master/packages/libra-rpc-graphql-server/README.md",
+  "dependencies": {
+    "apollo-server-express": "^2.0.0",
+    "express": "^4.0.0",
+    "graphql": "^14.0.0",
+    "graphql-tag": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.0.0"
+  },
+  "files": [
+    "dist/*",
+    "!tsconfig.tsbuildinfo"
+  ]
+}

--- a/packages/libra-rpc-graphql-server/src/graphql/LibraMint.ts
+++ b/packages/libra-rpc-graphql-server/src/graphql/LibraMint.ts
@@ -1,0 +1,33 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  mutation LibraMint($authKey: HexString!) {
+    mint(
+      input: {authKey: $authKey, amountInMicroLibras: 1e6, currencyCode: "LBR"}
+    ) {
+      sequenceNumber
+      address
+      balances {
+        ...amountFields
+      }
+      receivedEvents {
+        key
+        sequenceNumber
+        transactionVersion
+        data {
+          ... on ReceivedPaymentEventData {
+            amount {
+              ...amountFields
+            }
+            senderAddress
+          }
+        }
+      }
+    }
+  }
+
+  fragment amountFields on Amount {
+    amount
+    currency
+  }
+`;

--- a/packages/libra-rpc-graphql-server/src/graphql/LibraSeed.ts
+++ b/packages/libra-rpc-graphql-server/src/graphql/LibraSeed.ts
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  mutation LibraSeed {
+    createSeed {
+      phrase
+      key
+      wallet {
+        account {
+          authKey
+          address
+        }
+      }
+    }
+  }
+`;

--- a/packages/libra-rpc-graphql-server/src/graphql/LibraTestQuery.ts
+++ b/packages/libra-rpc-graphql-server/src/graphql/LibraTestQuery.ts
@@ -1,0 +1,181 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  query LibraTest($phrase: String!, $address: HexString!) {
+    metadata {
+      version
+      timestamp
+    }
+    wallet(phrase: $phrase) {
+      seed {
+        phrase
+        key
+      }
+      account {
+        secretKey
+        publicKey
+        authKey
+        address
+        libraAccount {
+          sequenceNumber
+          isFrozen
+          balances {
+            amount
+            currency
+          }
+          role
+        }
+      }
+    }
+    received: account(address: $address) {
+      receivedEvents {
+        ...receivedEventFields
+      }
+    }
+    sent: account(address: $address) {
+      sentEvents {
+        ...sentEventFields
+      }
+    }
+    transactions: account(address: $address) {
+      transactions {
+        version
+        hash
+        vmStatus
+        gasUsed
+        data {
+          __typename
+          ... on UserTransactionData {
+            ...userTransactionFields
+          }
+        }
+      }
+    }
+  }
+
+  fragment amountFields on Amount {
+    amount
+    currency
+  }
+
+  fragment accountFields on Account {
+    sequenceNumber
+    address
+    authenticationKey
+    balances {
+      ...amountFields
+    }
+  }
+
+  fragment sentEventDataFields on SentPaymentEventData {
+    amount {
+      ...amountFields
+    }
+    metadata
+    receiver {
+      ...accountFields
+    }
+  }
+
+  fragment receivedEventDataFields on ReceivedPaymentEventData {
+    amount {
+      ...amountFields
+    }
+    metadata
+    sender {
+      ...accountFields
+    }
+  }
+
+  fragment eventFields on Event {
+    sequenceNumber
+    transaction(includeEvents: true) {
+      version
+      hash
+      vmStatus
+      gasUsed
+      data {
+        ...userTransactionFields
+      }
+      events {
+        data {
+          __typename
+          ... on MintEventData {
+            amount {
+              ...amountFields
+            }
+          }
+        }
+      }
+    }
+    data {
+      __typename
+    }
+  }
+
+  fragment receivedEventFields on Event {
+    ...eventFields
+    transaction(includeEvents: true) {
+      events {
+        data {
+          ... on SentPaymentEventData {
+            ...sentEventDataFields
+          }
+        }
+      }
+    }
+    data {
+      ... on ReceivedPaymentEventData {
+        ...receivedEventDataFields
+      }
+    }
+  }
+
+  fragment sentEventFields on Event {
+    ...eventFields
+    transaction(includeEvents: true) {
+      events {
+        data {
+          ... on ReceivedPaymentEventData {
+            ...receivedEventDataFields
+          }
+        }
+      }
+    }
+    data {
+      ... on SentPaymentEventData {
+        ...sentEventDataFields
+      }
+    }
+  }
+
+  fragment userTransactionFields on UserTransactionData {
+    signatureScheme
+    signature
+    publicKey
+    sequenceNumber
+    maxGasAmount
+    gasUnitPrice
+    gasCurrency
+    expirationTimestampSecs
+    scriptHash
+    script {
+      __typename
+      ... on MintScript {
+        receiver {
+          ...accountFields
+        }
+        amount
+      }
+      ... on PeerToPeerTransferScript {
+        receiver {
+          ...accountFields
+        }
+        amount
+        currency
+        metadata
+        metadataSignature
+      }
+    }
+  }
+`;

--- a/packages/libra-rpc-graphql-server/src/graphql/index.ts
+++ b/packages/libra-rpc-graphql-server/src/graphql/index.ts
@@ -1,0 +1,3 @@
+export {default as libraMintMutation} from './LibraMint';
+export {default as libraSeedMutation} from './LibraSeed';
+export {default as libraTestQuery} from './LibraTestQuery';

--- a/packages/libra-rpc-graphql-server/src/index.ts
+++ b/packages/libra-rpc-graphql-server/src/index.ts
@@ -1,0 +1,6 @@
+import * as graphql from './graphql';
+import * as variables from './variables';
+
+export * from './server';
+
+export {graphql, variables};

--- a/packages/libra-rpc-graphql-server/src/server.ts
+++ b/packages/libra-rpc-graphql-server/src/server.ts
@@ -1,0 +1,104 @@
+import express, {Express} from 'express';
+import {
+  ApolloServer,
+  ApolloServerExpressConfig,
+  PlaygroundRenderPageOptions,
+} from 'apollo-server-express';
+import {print, GraphQLSchema} from 'graphql';
+
+import {libraMintMutation, libraSeedMutation, libraTestQuery} from './graphql';
+import {wallet} from './variables';
+
+export interface TabOptions {
+  endpoint?: string;
+  minter?: boolean;
+}
+
+export interface ServerOptions {
+  config?: Partial<ApolloServerExpressConfig>;
+  context?: ApolloServerExpressConfig['context'];
+  path?: string;
+  tabs?: true | Omit<TabOptions, 'endpoint'>;
+}
+
+export interface MiddlewareOptions {
+  app?: Express;
+}
+
+export const defaults = {
+  path: '/graphql',
+};
+
+export function createTabs({
+  endpoint = defaults.path,
+  minter,
+}: TabOptions = {}): PlaygroundRenderPageOptions['tabs'] {
+  const variables = JSON.stringify(wallet, null, 2);
+
+  const tabs = [
+    {
+      endpoint,
+      name: 'Libra Test Query',
+      query: print(libraTestQuery),
+      variables,
+    },
+    {
+      endpoint,
+      name: 'Libra Seed Creator',
+      query: print(libraSeedMutation),
+      variables,
+    },
+  ];
+
+  if (minter) {
+    tabs.push({
+      endpoint,
+      name: 'Libra Minter',
+      query: print(libraMintMutation),
+      variables,
+    });
+  }
+
+  return tabs;
+}
+
+export function createServer(
+  schema: GraphQLSchema,
+  {
+    config: {playground, ...config} = {},
+    context,
+    path = defaults.path,
+    tabs,
+  }: ServerOptions = {},
+) {
+  const tabOptions = getTabOptions();
+  const playgroundOptions = typeof playground === 'boolean' ? {} : playground;
+
+  return new ApolloServer({
+    context,
+    introspection: true,
+    playground: {
+      tabs: tabOptions ? createTabs(tabOptions) : undefined,
+      ...playgroundOptions,
+    },
+    schema,
+    ...config,
+  });
+
+  function getTabOptions() {
+    if (!tabs) {
+      return;
+    }
+
+    return tabs === true ? {endpoint: path} : {...tabs, endpoint: path};
+  }
+}
+
+export function applyMiddleware(
+  server: ApolloServer,
+  {app = express()}: MiddlewareOptions = {},
+) {
+  server.applyMiddleware({app, path: server.graphqlPath});
+
+  return app;
+}

--- a/packages/libra-rpc-graphql-server/src/test/server.test.ts
+++ b/packages/libra-rpc-graphql-server/src/test/server.test.ts
@@ -1,0 +1,139 @@
+import {
+  applyMiddleware,
+  createServer,
+  createTabs,
+  defaults,
+  ServerOptions,
+} from '../server';
+import {wallet} from '../variables';
+
+jest.mock('apollo-server-express', () => ({
+  ApolloServer: jest.fn(),
+}));
+jest.mock('express', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const ApolloServerMock: jest.Mock = jest.requireMock('apollo-server-express')
+  .ApolloServer;
+const expressMock: jest.Mock = jest.requireMock('express').default;
+
+describe('defaults', () => {
+  it('has a default path', () => {
+    expect(defaults).toMatchObject({path: '/graphql'});
+  });
+});
+
+describe('createTabs()', () => {
+  const variables = JSON.stringify(wallet, null, 2);
+
+  it('creates 2 tabs by default', () => {
+    expect(createTabs()).toHaveLength(2);
+  });
+
+  it('creates 3 tabs if the minter flag is set', () => {
+    expect(createTabs({minter: true})).toHaveLength(3);
+  });
+
+  it('uses the provided endpoint for each tab', () => {
+    const endpoint = '/test';
+    const tabs = createTabs({endpoint});
+
+    expect(tabs.map(({endpoint}) => endpoint)).toStrictEqual(
+      tabs.map(() => endpoint),
+    );
+  });
+
+  it('includes the wallet variables', () => {
+    const tabs = createTabs();
+
+    expect(tabs.map(({variables}) => variables)).toStrictEqual(
+      tabs.map(() => variables),
+    );
+  });
+
+  it('creates a test query by default', () => {
+    expect(createTabs()).toContainEqual(
+      expect.objectContaining({name: 'Libra Test Query'}),
+    );
+  });
+
+  it('creates a seed creator mutation by default', () => {
+    expect(createTabs()).toContainEqual(
+      expect.objectContaining({name: 'Libra Seed Creator'}),
+    );
+  });
+
+  it('creates a minter mutation if the minter flag is set', () => {
+    expect(createTabs({minter: true})).toContainEqual(
+      expect.objectContaining({name: 'Libra Minter'}),
+    );
+  });
+});
+
+describe('createServer()', () => {
+  afterEach(() => {
+    ApolloServerMock.mockRestore();
+  });
+
+  it('creates an apollo server with the provided schema', () => {
+    const schema: any = {};
+
+    createServer(schema);
+
+    expect(ApolloServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({schema}),
+    );
+  });
+
+  it('creates an apollo server with the provided options', () => {
+    const config: ServerOptions['config'] = {debug: true};
+    const context: ServerOptions['context'] = {};
+    const options: ServerOptions = {
+      config,
+      context,
+    };
+
+    createServer({} as any, options);
+
+    expect(ApolloServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({...config, context}),
+    );
+  });
+});
+
+describe('applyMiddleware()', () => {
+  afterEach(() => {
+    expressMock.mockRestore();
+  });
+
+  it('calls applyMiddleware on the server using the server graphqlPath', () => {
+    const applyMiddlewareMock = jest.fn();
+    const path = '/test';
+    const app: any = {};
+    const server: any = {
+      applyMiddleware: applyMiddlewareMock,
+      graphqlPath: path,
+    };
+
+    applyMiddleware(server, {app});
+
+    expect(applyMiddlewareMock).toHaveBeenCalledWith({app, path});
+  });
+
+  it('returns the app', () => {
+    const app: any = {};
+    const server: any = {applyMiddleware: () => {}, graphqlPath: '/test'};
+
+    expect(applyMiddleware(server, {app})).toBe(app);
+  });
+
+  it('creates an app if not provided', () => {
+    const app: any = {};
+    const server: any = {applyMiddleware: () => {}, graphqlPath: '/test'};
+    expressMock.mockReturnValue(app);
+
+    expect(applyMiddleware(server)).toBe(app);
+  });
+});

--- a/packages/libra-rpc-graphql-server/src/variables.ts
+++ b/packages/libra-rpc-graphql-server/src/variables.ts
@@ -1,0 +1,10 @@
+// these variables are the result of the LibraSeed mutation
+export const wallet = {
+  phrase:
+    'resource setup claim iron carpet east dose truck dry file olympic february own federal pioneer total candy beef usage heart relax dance library height',
+  key: 'f080ac2748fde3a53318492f8466b200b39afc3b09a496433db6dcca1243953d',
+  secretKey: '81212144b0f8358aaa94ff5f595d5a1274527ce325ff508fe27748e607850463',
+  publicKey: 'dc741284bd42ec0c9250706c4bbe9a651fe8b1ba2cd5b28f9b09f813cb02f3e1',
+  authKey: '239ed09c441bb3307b3c5abc878879581d0a20b6462d3e8dbb21784b1f1314e9',
+  address: '1d0a20b6462d3e8dbb21784b1f1314e9',
+};

--- a/packages/libra-rpc-graphql-server/tsconfig.json
+++ b/packages/libra-rpc-graphql-server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig_base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "rootDir": "."
+  },
+  "include": [
+    "../../config/typescript/**/*",
+    "./src/**/*.ts",
+    "./src/**/*.tsx"
+  ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -3,6 +3,7 @@
   "include": [],
   "references": [
     {"path": "./libra-rpc-graphql"},
+    {"path": "./libra-rpc-graphql-server"},
     {"path": "./libra-web-wallet-utils"}
   ]
 }


### PR DESCRIPTION
## Description

adding a new `libra-rpc-graphql-server` package that will offload all the `express` and `apollo-server` logic from the `libra-rpc-graphql` package.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
